### PR TITLE
Rename module interface name factory entity

### DIFF
--- a/hilt-binder-compiler/src/main/java/com/paulrybitskyi/hiltbinder/processor/factories/ModuleInterfaceNameFactory.kt
+++ b/hilt-binder-compiler/src/main/java/com/paulrybitskyi/hiltbinder/processor/factories/ModuleInterfaceNameFactory.kt
@@ -18,7 +18,7 @@ package com.paulrybitskyi.hiltbinder.processor.factories
 
 import com.paulrybitskyi.hiltbinder.processor.model.HiltComponent
 
-internal class FileInterfaceNameFactory {
+internal class ModuleInterfaceNameFactory {
 
 
     private companion object {

--- a/hilt-binder-compiler/src/main/java/com/paulrybitskyi/hiltbinder/processor/factories/ModuleSchemaFactory.kt
+++ b/hilt-binder-compiler/src/main/java/com/paulrybitskyi/hiltbinder/processor/factories/ModuleSchemaFactory.kt
@@ -23,7 +23,7 @@ import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Elements
 
 internal class ModuleSchemaFactory(
-    private val fileInterfaceNameFactory: FileInterfaceNameFactory,
+    private val moduleInterfaceNameFactory: ModuleInterfaceNameFactory,
     private val elementUtils: Elements
 ) {
 
@@ -35,7 +35,7 @@ internal class ModuleSchemaFactory(
     ): ModuleSchema {
         return ModuleSchema(
             packageName = packageName,
-            interfaceName = fileInterfaceNameFactory.createInterfaceName(component),
+            interfaceName = moduleInterfaceNameFactory.createInterfaceName(component),
             componentType = component.toTypeElement(),
             bindings = bindings
         )

--- a/hilt-binder-compiler/src/main/java/com/paulrybitskyi/hiltbinder/processor/parser/AnnotationsParserFactory.kt
+++ b/hilt-binder-compiler/src/main/java/com/paulrybitskyi/hiltbinder/processor/parser/AnnotationsParserFactory.kt
@@ -20,7 +20,7 @@ import com.paulrybitskyi.hiltbinder.processor.ComponentMapper
 import com.paulrybitskyi.hiltbinder.processor.detectors.*
 import com.paulrybitskyi.hiltbinder.processor.factories.BindingMethodNameFactory
 import com.paulrybitskyi.hiltbinder.processor.factories.BindingSchemaFactory
-import com.paulrybitskyi.hiltbinder.processor.factories.FileInterfaceNameFactory
+import com.paulrybitskyi.hiltbinder.processor.factories.ModuleInterfaceNameFactory
 import com.paulrybitskyi.hiltbinder.processor.factories.ModuleSchemaFactory
 import com.paulrybitskyi.hiltbinder.processor.providers.PackageNameProvider
 import javax.annotation.processing.ProcessingEnvironment
@@ -99,14 +99,14 @@ internal object AnnotationsParserFactory {
 
     private fun createModuleSchemaFactory(env: ProcessingEnvironment): ModuleSchemaFactory {
         return ModuleSchemaFactory(
-            fileInterfaceNameFactory = createFileInterfaceNameFactory(),
+            moduleInterfaceNameFactory = createModuleInterfaceNameFactory(),
             elementUtils = env.elementUtils
         )
     }
 
 
-    private fun createFileInterfaceNameFactory(): FileInterfaceNameFactory {
-        return FileInterfaceNameFactory()
+    private fun createModuleInterfaceNameFactory(): ModuleInterfaceNameFactory {
+        return ModuleInterfaceNameFactory()
     }
 
 

--- a/hilt-binder-compiler/src/test/java/com/paulrybitskyi/hiltbinder/processor/HiltBinderTest.kt
+++ b/hilt-binder-compiler/src/test/java/com/paulrybitskyi/hiltbinder/processor/HiltBinderTest.kt
@@ -21,7 +21,7 @@ import com.google.testing.compile.JavaFileObjects.forResource
 import com.google.testing.compile.JavaFileObjects.forSourceLines
 import com.google.testing.compile.JavaSourcesSubjectFactory.javaSources
 import com.paulrybitskyi.hiltbinder.BindType
-import com.paulrybitskyi.hiltbinder.processor.factories.FileInterfaceNameFactory
+import com.paulrybitskyi.hiltbinder.processor.factories.ModuleInterfaceNameFactory
 import com.paulrybitskyi.hiltbinder.processor.model.HiltComponent
 import com.paulrybitskyi.hiltbinder.processor.model.WITH_FRAGMENT_BINDINGS_TYPE_CANON_NAME
 import com.paulrybitskyi.hiltbinder.processor.providers.MessageProvider
@@ -33,7 +33,7 @@ internal class HiltBinderTest {
     private companion object {
 
         private val COMPONENT_MAPPER = ComponentMapper()
-        private val FILE_INTERFACE_NAME_FACTORY = FileInterfaceNameFactory()
+        private val MODULE_INTERFACE_NAME_FACTORY = ModuleInterfaceNameFactory()
         private val MESSAGE_PROVIDER = MessageProvider()
 
         private val VALID_ANNOTATION_COMPONENTS = BindType.Component
@@ -390,7 +390,7 @@ internal class HiltBinderTest {
                 public class Test implements Testable {}
             """.trimIndent()
             )
-            val interfaceName = FILE_INTERFACE_NAME_FACTORY.createInterfaceName(hiltComponent)
+            val interfaceName = MODULE_INTERFACE_NAME_FACTORY.createInterfaceName(hiltComponent)
             val expectedModule = forSourceLines(
                 interfaceName,
                 """
@@ -435,7 +435,7 @@ internal class HiltBinderTest {
             """.trimIndent()
             )
             val hiltComponent = COMPONENT_MAPPER.mapToHiltComponent(component)
-            val interfaceName = FILE_INTERFACE_NAME_FACTORY.createInterfaceName(hiltComponent)
+            val interfaceName = MODULE_INTERFACE_NAME_FACTORY.createInterfaceName(hiltComponent)
             val expectedModule = forSourceLines(
                 interfaceName,
                 """


### PR DESCRIPTION
Rename `FileInterfaceNameFactory` class to `ModuleInterfaceNameFactory`.