### PR TITLE
Downgrade Java version from 11 to 8

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,8 +27,8 @@ object appConfig {
     const val versionCode = 1
     const val versionName = "1.0.0"
 
-    val javaCompatibilityVersion = JavaVersion.VERSION_11
-    val kotlinCompatibilityVersion = JavaVersion.VERSION_11
+    val javaCompatibilityVersion = JavaVersion.VERSION_1_8
+    val kotlinCompatibilityVersion = JavaVersion.VERSION_1_8
 }
 
 object publishingConfig {


### PR DESCRIPTION
Compiling libraries with Java 11 has major implications on end-users, who will have to bump their projects' Java version to 11 as well to be able to compile them. This is a major issue, since libraries, especially third-party ones, do not have impose such restrictions.